### PR TITLE
feat: add pre tag to fix message inline issue

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,3 @@
-
 <div class="chat">
   <h3>Chat here to know Nuttakit more <img src="assets/work-in-progress.png"></h3>
   <div class="chat-content">
@@ -11,7 +10,9 @@
       <div #messages class="message" *ngFor="let message of chat.allMessages()">
         <div class="{{message.type}}">
           <span class="time">{{ message.timestamp | date: 'shortTime' }}</span>
-          <span class="text">{{ message.text }}</span>
+          <span class="text">
+            <pre>{{ message.text }}</pre>
+          </span>
           <div class="profile-section">
             <img class="profile-img" [src]="profileImg[message.type]">
           </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -48,15 +48,19 @@ h3 {
   display: flex;
   width: 100%;
   font-size: var(--font-size);
-  font-family: var(--font-family);
-
   span {
     &.text {
       padding: 10px;
       border: 1px solid black;
       border-radius: 15px;
+      pre {
+        font-family: var(--font-family);
+        margin: 0px;
+        text-wrap: wrap;
+      }
     }
     &.time {
+      font-family: var(--font-family);
       padding: 5px;
       display: flex;
       align-items: self-end;


### PR DESCRIPTION
There was an issue. Everything is in the same line. It's hard to read.

<img width="965" alt="Screenshot 2566-10-03 at 19 03 14" src="https://github.com/nutphi/personal-chat/assets/13303285/958db82d-30e7-4bd4-8550-9ac396b63060">

After adding pre tag, the result is like this.
<img width="963" alt="Screenshot 2566-10-03 at 19 16 24" src="https://github.com/nutphi/personal-chat/assets/13303285/396ab56d-1ad0-4583-9a15-2bfcef27a4a5">

