### PR TITLE
feat: update pre word wrap css on phone

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -56,7 +56,9 @@ h3 {
       pre {
         font-family: var(--font-family);
         margin: 0px;
-        text-wrap: wrap;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        overflow: auto;
       }
     }
     &.time {


### PR DESCRIPTION
on phone, I got this issue.

<img src="https://github.com/nutphi/personal-chat/assets/13303285/c1d3adc6-cdd9-42d1-b0b2-007eabfb1109" width="100">

I added css on pre element to fix the issue.

```
white-space: pre-wrap;
word-wrap: break-word;
overflow: auto;
```